### PR TITLE
Align with cluster-compare v4.19.0 diff

### DIFF
--- a/ansible/roles/telco-core-manifests/templates/extra-manifests/sctp_module_mc.yaml
+++ b/ansible/roles/telco-core-manifests/templates/extra-manifests/sctp_module_mc.yaml
@@ -10,17 +10,16 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
-        - contents:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          contents:
             source: data:,
             verification: {}
           filesystem: root
           mode: 420
-          path: /etc/modprobe.d/sctp-blacklist.conf
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,c2N0cA==
-          filesystem: root
+        - path: /etc/modules-load.d/sctp-load.conf
+          contents:
+            source: data:,sctp
           mode: 420
-          path: /etc/modules-load.d/sctp-load.conf


### PR DESCRIPTION
cluster-compare (v4.19.0) is accusing a diff from this manifest, which also seems to have a typo (with the wrong ignition config version) in the [reference](https://github.com/openshift-kni/telco-reference/blob/release-4.18/telco-core/install/extra-manifests/sctp_module_mc.yaml#L13):

```
Cluster CR: machineconfiguration.openshift.io/v1_MachineConfig_load-sctp-module
Reference File: optional/other/sctp_module_mc.yaml
Description:
  https://docs.openshift.com/container-platform/4.17/scalability_and_performance/telco_ref_design_specs/core/telco-core-ref-crs.html#node-configuration-crs_ran-core-ref-design-crs
Diff Output: diff -u -N /tmp/MERGED-675760767/machineconfiguration-openshift-io-v1_machineconfig_load-sctp-module /tmp/LIVE-38140128/machineconfiguration-openshift-io-v1_machineconfig_load-sctp-module
--- /tmp/MERGED-675760767/machineconfiguration-openshift-io-v1_machineconfig_load-sctp-module	2025-07-02 07:49:01.583315484 +0000
+++ /tmp/LIVE-38140128/machineconfiguration-openshift-io-v1_machineconfig_load-sctp-module	2025-07-02 07:49:01.583315484 +0000
@@ -7,16 +7,16 @@
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 2.2.0
     storage:
       files:
       - contents:
           source: data:,
+          verification: {}
+        filesystem: root
         mode: 420
-        overwrite: true
         path: /etc/modprobe.d/sctp-blacklist.conf
       - contents:
           source: data:,sctp
         mode: 420
-        overwrite: true
         path: /etc/modules-load.d/sctp-load.conf
```


CC: @imiller0