### PR TITLE
Draft: Add option for PolicyGenerator policies to telco-ran-du-ztp role

### DIFF
--- a/ansible/roles/telco-ran-du-ztp/defaults/main.yml
+++ b/ansible/roles/telco-ran-du-ztp/defaults/main.yml
@@ -69,3 +69,6 @@ extraHubCommonTemplates: false
 extraHubGroupTemplates: false
 # When enabled, creates extra annotations from site specific ConfigMaps on hub in group PGT
 extraHubSiteTemplates: false
+
+# When enabled use ACM PolicyGenerator instead of RAN PolicyGenTemplate to generate ACM policies
+acm_policygenerator: false

--- a/ansible/roles/telco-ran-du-ztp/tasks/main.yml
+++ b/ansible/roles/telco-ran-du-ztp/tasks/main.yml
@@ -113,28 +113,41 @@
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/cluster-applications/ztp-clusters-{{ '%02d' | format(item) }}.yaml"
   loop: "{{ range(1, cluster_applications_count + 1) | list }}"
 
+- name: Copy files required when using PolicyGenerator
+  block:
+    - name: Copy source-crs when using PolicyGenerator
+      copy:
+        src: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/source-crs"
+        dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/"
+
+    - name: Copy schema.openapi when using PolicyGenerator
+      copy:
+        src: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/example/acmpolicygenerator/schema.openapi"
+        dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/"
+  when: acm_policygenerator
+
 - name: Template the DU Profile policy manifests into cnf-features-deploy
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   loop:
-  - src: pgt-du-{{ du_profile_version }}/common-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/common-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/common-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/common-mno-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/common-mno-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/common-mno-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-sno-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-sno-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-sno-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-sno-validator-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-sno-validator-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-sno-validator-ranGen.yaml"
   - src: sno-site.yaml
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/sno-site.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-3node-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-3node-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-3node-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-3node-validator-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-3node-validator-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-3node-validator-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-standard-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-standard-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-standard-ranGen.yaml"
-  - src: pgt-du-{{ du_profile_version }}/group-du-standard-validator-ranGen.yaml
+  - src: "{{ acm_policygenerator | ternary('pg','pgt') }}-du-{{ du_profile_version }}/group-du-standard-validator-ranGen.yaml"
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/group-du-standard-validator-ranGen.yaml"
   - src: policy-kustomization.yaml
     dest: "{{ install_directory }}/rhacm-ztp/cnf-features-deploy/ztp/gitops-subscriptions/argocd/policy/common-and-group/kustomization.yaml"

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/common-mno-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/common-mno-ranGen.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+    name: common-mno-latest
+placementBindingDefaults:
+    name: common-mno-latest-placement-binding
+policyDefaults:
+    namespace: ztp-common
+    placement:
+        labelSelector:
+            matchExpressions:
+                - key: common
+                  operator: In
+                  values:
+                    - "true"
+                - key: du-profile
+                  operator: In
+                  values:
+                    - latest
+    remediationAction: inform
+    severity: low
+    namespaceSelector:
+        exclude:
+            - kube-*
+        include:
+            - '*'
+    evaluationInterval:
+        compliant: 10m
+        noncompliant: 10s
+policies:
+    - name: common-mno-latest-config-policy
+      policyAnnotations:
+        ran.openshift.io/ztp-deploy-wave: "1"
+      manifests:
+        - path: source-crs/OperatorHub.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/common-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/common-ranGen.yaml
@@ -1,0 +1,86 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: common-latest
+placementBindingDefaults:
+  name: common-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-common
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      common: "true"
+      du-profile: "latest"
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: common-latest-config-policy
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "1"
+  manifests:
+    - path: source-crs/ReduceMonitoringFootprint.yaml
+    - path: source-crs/DefaultCatsrc.yaml
+      patches:
+      - metadata:
+          name: redhat-operators-disconnected
+        spec:
+          displayName: disconnected-redhat-operators
+          image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
+    - path: source-crs/DisconnectedICSP.yaml
+      patches:
+      - spec:
+          repositoryDigestMirrors:
+          - mirrors:
+            - registry.example.com:5000
+            source: registry.redhat.io
+- name: common-latest-subscriptions-policy
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+  manifests:
+    # Logging operator
+    - path: source-crs/ClusterLogNS.yaml
+    - path: source-crs/ClusterLogOperGroup.yaml
+    - path: source-crs/ClusterLogSubscription.yaml
+    - path: source-crs/ClusterLogOperatorStatus.yaml
+    - path: source-crs/ClusterLogServiceAccount.yaml
+    - path: source-crs/ClusterLogServiceAccountAuditBinding.yaml
+    - path: source-crs/ClusterLogServiceAccountInfrastructureBinding.yaml
+    # Ptp operator
+    - path: source-crs/PtpSubscriptionNS.yaml
+    - path: source-crs/PtpSubscription.yaml
+    - path: source-crs/PtpSubscriptionOperGroup.yaml
+    - path: source-crs/PtpOperatorStatus.yaml
+    # SRIOV operator
+    - path: source-crs/SriovSubscriptionNS.yaml
+    - path: source-crs/SriovSubscriptionOperGroup.yaml
+    - path: source-crs/SriovSubscription.yaml
+    - path: source-crs/SriovOperatorStatus.yaml
+    # Storage operator
+    - path: source-crs/StorageNS.yaml
+    - path: source-crs/StorageOperGroup.yaml
+    - path: source-crs/StorageSubscription.yaml
+    - path: source-crs/StorageOperatorStatus.yaml
+    #
+    # LCA operator is used for orchestrating Image Based Upgrade for SNO
+    # - path: source-crs/LcaSubscriptionNS.yaml
+    # - path: source-crs/LcaSubscriptionOperGroup.yaml
+    # - path: source-crs/LcaSubscription.yaml
+    # - path: source-crs/LcaOperatorStatus.yaml
+    #
+    # OADP operator is used for backing up and restoring application during Image Based Upgrade
+    # - path: source-crs/OadpSubscriptionNS.yaml
+    # - path: source-crs/OadpSubscriptionOperGroup.yaml
+    # - path: source-crs/OadpSubscription.yaml
+    # - path: source-crs/OadpOperatorStatus.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-3node-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-3node-ranGen.yaml
@@ -1,0 +1,80 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-3node-latest
+placementBindingDefaults:
+  name: group-du-3node-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      group-du-3node: ""
+      du-profile: "latest"
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: group-du-3node-latest-config-policy
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+  manifests:
+    - path: source-crs/PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
+      patches:
+      - metadata:
+          name: du-ptp-slave
+        spec:
+          profile:
+              - interface: ens5f0
+                name: slave
+                phc2sysOpts: -a -r -n 24
+                ptp4lOpts: -2 -s --summary_interval -4
+      openapi:
+        path: schema.openapi
+    - path: source-crs/SriovOperatorConfig-SetSelector.yaml
+      # For existing clusters with node selector set as "master", 
+      # change the complianceType to "mustonlyhave".
+      # After complying with the policy, the complianceType can 
+      # be reverted to "musthave"
+      complianceType: musthave
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/master: ""
+    - path: source-crs/PerformanceProfile-SetSelector.yaml
+      patches:
+      - spec:
+          cpu:
+            # These must be tailored for the specific hardware platform
+            isolated: "2-19,22-39"
+            reserved: "0-1,20-21"
+          hugepages:
+            defaultHugepagesSize: 1G
+            pages:
+            - size: 1G
+              count: 32
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/master: ""
+          nodeSelector:
+            node-role.kubernetes.io/master: ''
+    - path: source-crs/TunedPerformancePatch.yaml
+      patches:
+      - spec:
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "master"
+            priority: 19
+            profile: performance-patch
+    - path: source-crs/optional-extra-manifest/enable-crun-master.yaml
+    - path: source-crs/optional-extra-manifest/enable-crun-worker.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-3node-validator-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-3node-validator-ranGen.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-3node-validator-latest
+placementBindingDefaults:
+  name: group-du-3node-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: group-du-3node
+        operator: Exists
+      - key: du-profile
+        operator: In
+        values: ["latest"]
+      - key: ztp-done
+        operator: DoesNotExist
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+   # using a bindingExcludeRules entry with ztp-done
+    compliant: 5s
+    noncompliant: 10s
+policies:
+- name: group-du-3node-validator-latest-du-policy
+  policyAnnotations:
+    ran.openshift.io/soak-seconds: "30"
+    ran.openshift.io/ztp-deploy-wave: "10000"
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorMaster.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-sno-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-sno-ranGen.yaml
@@ -1,0 +1,186 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-sno-latest
+placementBindingDefaults:
+  name: group-du-sno-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      group-du-sno: ""
+      du-profile: "latest"
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: group-du-sno-latest-config-policy
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+  manifests:
+    - path: source-crs/DisableOLMPprof.yaml
+    - path: source-crs/ClusterLogForwarder.yaml
+      patches:
+      - spec:
+          filters:
+            - name: ran-du-labels
+              openshiftLabels:
+                label1: test1
+                label2: test2
+                label3: test3
+                label4: test4
+          outputs:
+            - kafka:
+                url: tcp://10.46.55.190:9092/test
+              name: kafka-output
+      openapi:
+        path: schema.openapi
+    ## The setting below overrides the default "worker" selector predefined in
+    ## the source-crs. The change is recommended on SNOs configured with PTP 
+    ## event notification for forward compatibility with possible SNO expansion.
+    ## When the default setting is left intact, then in case of an SNO 
+    ## expansion with one or more workers, PTP operator
+    ## would not create linuxptp-daemon containers on the worker node(s). Any
+    ## attempt to change the daemonsetNodeSelector will result in ptp daemon
+    ## restart and time synchronization loss.
+    ## After complying with the policy, complianceType can be set to a safer "musthave"
+#    - path: source-crs/PtpOperatorConfigForEvent.yaml
+#      complianceType: "mustonlyhave"
+#      patches:
+#      - spec:
+#          daemonNodeSelector:
+#            node-role.kubernetes.io/worker: ""
+    - path: source-crs/PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
+      patches:
+        - metadata:
+            name: du-ptp-slave
+          spec:
+            profile:
+                - interface: ens5f0
+                  name: slave
+                  phc2sysOpts: -a -r -n 24
+                  ptp4lOpts: -2 -s --summary_interval -4
+      openapi:
+        path: schema.openapi
+    - path: source-crs/SriovOperatorConfig-SetSelector.yaml
+      ## For existing clusters with node selector set as "master", 
+      ## change the complianceType to "mustonlyhave".
+      ## After complying with the policy, the complianceType can 
+      ## be reverted to "musthave"
+      complianceType: musthave
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/worker: ""
+    - path: source-crs/StorageLV.yaml
+      patches:
+      - spec:
+          storageClassDevices:
+          - storageClassName: "example-storage-class-1"
+            volumeMode: Filesystem
+            fsType: xfs
+            devicePaths:
+            - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+          - storageClassName: "example-storage-class-2"
+            volumeMode: Filesystem
+            fsType: xfs
+            devicePaths:
+            - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+        ## This is required if PTP and BMER operators use HTTP transport.
+        ## The disk labels are created by ignitionConfigOverride in siteConfig.
+        ## - storageClassName: "storage-class-http-events"
+        ##   volumeMode: Filesystem
+        ##   fsType: xfs
+        ##   devicePaths:
+        ##   - /dev/disk/by-partlabel/httpevent1
+        ##   - /dev/disk/by-partlabel/httpevent2
+    - path: source-crs/DisableSnoNetworkDiag.yaml
+    - path: source-crs/PerformanceProfile-SetSelector.yaml
+      patches:
+      - spec:
+          cpu:
+            # These must be tailored for the specific hardware platform
+            isolated: "2-31,34-63"
+            reserved: "0-1,52-53"
+          hugepages:
+            defaultHugepagesSize: 1G
+            pages:
+            - size: 1G
+              count: 32
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/master: ""
+          nodeSelector:
+            node-role.kubernetes.io/master: ''
+    - path: source-crs/TunedPerformancePatch.yaml
+      patches:
+      - spec:
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "master"
+            priority: 19
+            profile: performance-patch
+    - path: source-crs/optional-extra-manifest/enable-crun-master.yaml
+    - path: source-crs/optional-extra-manifest/enable-crun-worker.yaml
+#    - path: source-crs/StorageClass.yaml
+#      patches:
+#      - metadata:
+#          name: image-registry-sc
+#    - path: source-crs/StoragePVC.yaml
+#      patches:
+#      - metadata:
+#          name: image-registry-pvc
+#          namespace: openshift-image-registry
+#        spec:
+#          accessModes:
+#            - ReadWriteMany
+#          resources:
+#            requests:
+#              storage: 100Gi
+#          storageClassName: image-registry-sc
+#          volumeMode: Filesystem
+#    - path: source-crs/ImageRegistryPV.yaml
+#    - path: source-crs/ImageRegistryConfig.yaml
+#      patches:
+#      - spec:
+#          storage:
+#            pvc:
+#              claim: "image-registry-pvc"
+##   --- sources needed for updating CRI-O workload-partitioning ----
+##      more info here: on the base64 content https://docs.openshift.com/container-platform/4.11/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html
+#    - path: source-crs/MachineConfigGeneric.yaml
+#      complianceType: mustonlyhave
+#      patches:
+#      - metadata:
+#          name: 02-master-workload-partitioning
+#        spec:
+#          config:
+#            storage:
+#              files:
+#                - contents:
+                   # crio cpuset config goes below. This value needs to updated and matched PerformanceProfile. Check the link for more info on the content.
+#                    source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSw1Mi01MyIgfQo=
+#                  mode: 420
+#                  overwrite: true
+#                  path: /etc/crio/crio.conf.d/01-workload-partitioning
+#                  user:
+#                    name: root
+#                - contents:
+                   # openshift cpuset config goes below. This value needs to be updated and matched with crio cpuset (array entry above this). Check the link for more info on the content.
+#                    source: data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg==
+#                  mode: 420
+#                  overwrite: true
+#                  path: /etc/kubernetes/openshift-workload-pinning
+#                  user:
+#                    name: root

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-sno-validator-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-sno-validator-ranGen.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-sno-validator-latest
+placementBindingDefaults:
+  name: group-du-sno-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: group-du-sno
+        operator: Exists
+      - key: du-profile
+        operator: In
+        values: ["latest"]
+      - key: ztp-done
+        operator: DoesNotExist
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+   # using a bindingExcludeRules entry with ztp-done
+    compliant: 5s
+    noncompliant: 10s
+policies:
+- name: group-du-sno-validator-latest-du-policy
+  policyAnnotations:
+    ran.openshift.io/soak-seconds: "30"
+    ran.openshift.io/ztp-deploy-wave: "10000"
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorMaster.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-standard-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-standard-ranGen.yaml
@@ -1,0 +1,85 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-standard-latest
+placementBindingDefaults:
+  name: group-du-standard-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      group-du-standard: ""
+      du-profile: "latest"
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+    compliant: 10m
+    noncompliant: 10s
+policies:
+- name: group-du-standard-latest-config-policy
+  policyAnnotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+  manifests:
+    - path: source-crs/PtpOperatorConfig-SetSelector.yaml
+      patches:
+      - spec:
+          daemonNodeSelector:
+            node-role.kubernetes.io/worker: ""
+    - path: source-crs/PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
+      patches:
+        - metadata:
+            name: du-ptp-slave
+          spec:
+            profile:
+                - interface: ens5f0
+                  name: slave
+                  phc2sysOpts: -a -r -n 24
+                  ptp4lOpts: -2 -s --summary_interval -4
+      openapi:
+        path: schema.openapi
+    - path: source-crs/SriovOperatorConfig-SetSelector.yaml
+      # For existing clusters with node selector set as "master", 
+      # change the complianceType to "mustonlyhave".
+      # After complying with the policy, the complianceType can 
+      # be reverted to "musthave"
+      complianceType: musthave
+      patches:
+      - spec:
+          configDaemonNodeSelector:
+            node-role.kubernetes.io/worker: ""
+    - path: source-crs/PerformanceProfile-SetSelector.yaml
+      patches:
+      - spec:
+          cpu:
+            # These must be tailored for the specific hardware platform
+            isolated: "2-19,22-39"
+            reserved: "0-1,20-21"
+          hugepages:
+            defaultHugepagesSize: 1G
+            pages:
+            - size: 1G
+              count: 32
+          machineConfigPoolSelector:
+            pools.operator.machineconfiguration.openshift.io/worker: ""
+          nodeSelector:
+            node-role.kubernetes.io/worker: ''
+    - path: source-crs/TunedPerformancePatch.yaml
+      patches:
+      - spec:
+          recommend:
+          - machineConfigLabels:
+              machineconfiguration.openshift.io/role: "worker"
+            priority: 19
+            profile: performance-patch
+    - path: source-crs/optional-extra-manifest/enable-crun-master.yaml
+    - path: source-crs/optional-extra-manifest/enable-crun-worker.yaml

--- a/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-standard-validator-ranGen.yaml
+++ b/ansible/roles/telco-ran-du-ztp/templates/pg-du-4.18/group-du-standard-validator-ranGen.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: group-du-standard-validator-latest
+placementBindingDefaults:
+  name: group-du-standard-placement-binding
+policyDefaults:
+  # categories: []
+  #controls:
+  #  - PR.DS-1 Data-at-rest
+  namespace: ztp-group
+  # Use an existing placement rule so that placement bindings can be consolidated
+  placement:
+    labelSelector:
+      matchExpressions:
+      - key: group-du-standard
+        operator: Exists
+      - key: du-profile
+        operator: In
+        values: ["latest"]
+      - key: ztp-done
+        operator: DoesNotExist
+  remediationAction: inform
+  severity: low
+  # standards: []
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - '*'
+  evaluationInterval:
+   # This low setting is only valid if the validation policy is disconnected from the cluster at steady-state
+   # using a bindingExcludeRules entry with ztp-done
+    compliant: 5s
+    noncompliant: 10s
+policies:
+- name: group-du-standard-validator-latest-du-policy
+  policyAnnotations:
+    ran.openshift.io/soak-seconds: "30"
+    ran.openshift.io/ztp-deploy-wave: "10000"
+  manifests:
+    - path: source-crs/validatorCRs/informDuValidatorWorker.yaml


### PR DESCRIPTION
This change adds a new `acm_policygenerator` variable to the `telco-ran-du-ztp` role which controls whether to use ACM PolicyGenerator instead of RAN PolicyGenTemplate to generate ACM policies.